### PR TITLE
Add default throttle limit based upon logical CPU count.

### DIFF
--- a/Example/Invoke-TlsProtocolTest.ps1
+++ b/Example/Invoke-TlsProtocolTest.ps1
@@ -1,19 +1,61 @@
 # This is an example of using powershell 7's ForEach-Object -Parallel to spawn off concurrent threads to scan multiple systems simultaneously.
-$InputPath = 'example.csv'
-$ThrottleLimit = '8'
-$dictionary = [System.Collections.Concurrent.ConcurrentDictionary[string,object]]::new()
-if ($InputPath) {
-    Import-Csv -Path $InputPath | ForEach-Object -Parallel {
-        $record = $_
-        $server = $record.server
-        $ports = $record.ports
-        $dict = $using:dictionary
-        Write-Verbose "Fqdn: $fqdn"
-        Write-Verbose "Ports: $ports"
-        Import-Module "../Test-TlsProtocols/Test-TlsProtocols.psm1"
-        $result = Test-TlsProtocols -Server $server -Ports $Ports -IncludeRemoteCertificateInfo
-        $dict.TryAdd($server,$result)
-    } -ThrottleLimit $ThrottleLimit
-    $dictionary["github.com"]
-    # TO-DO: Add threadsafe ooperation to save output to a single csv file
+function Invoke-TlsProtocolTest {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$InputCsvFilePath,
+        [int32]$ThrottleLimit
+    )
+    
+    begin {
+        if (-not (Test-Path $InputCsvFilePath)) {
+            Write-Error "Cannot find $InputCsvFilePath`." -ErrorAction Stop
+        }
+        if(-not $ThrottleLimit) {
+            if ($isWindows) {
+                Write-Verbose "isWindows: $isWindows"
+                [int32]$ThrottleLimit = (Get-WmiObject Win32_Processor).Count
+            }
+            elseif ($isMacOS) {
+                [int32]$ThrottleLimit = sysctl -n hw.logicalcpu
+                Write-Verbose "isMacOS: $isMacOS`."
+            }
+            elseif ($isLinux) {
+                [int32]$ThrottleLimit = python -c 'import multiprocessing as mp; print(mp.cpu_count())'
+                Write-Verbose "isLinux: $isLinux`."
+            }
+            else {
+                $ThrottleLimit = 5 # Microsoft's default value for ForEach-Object -Parallel
+                Write-Verbose "Cannot determine OS."
+            }
+        }
+        Write-Verbose "InputCsvFilePath: $InputCsvFilePath"
+        Write-Verbose "ThrottleLimit: $ThrottleLimit"
+    }
+    
+    process {
+        $ConcurrentDictionary = [System.Collections.Concurrent.ConcurrentDictionary[string,object]]::new()
+        # TO-DO: Add threadsafe ooperation to save output to a single csv file
+        # $ConcurrentQueue = [System.Collections.Concurrent.ConcurrentQueue[object]]
+        Import-Csv -Path $InputCsvFilePath | ForEach-Object -Parallel {
+            $record = $_
+            $server = $record.server
+            $port = $record.port
+            $dictitonary = $using:ConcurrentDictionary
+            Write-Verbose "Fqdn: $fqdn"
+            Write-Verbose "Ports: $ports"
+            Import-Module "../Test-TlsProtocols/Test-TlsProtocols.psm1"
+            $result = Test-TlsProtocols -Server $server -Port $Port -IncludeRemoteCertificateInfo
+            $dictitonary.TryAdd($server,$result)
+        } -ThrottleLimit $ThrottleLimit
+    }
+    end {
+        $ConcurrentDictionary
+    }
+} # Invoke-TlsProtocolTest
+if (-not (Get-Module 'Test-TlsProtocols')) {
+    Import-Module 'Test-TlsProtocols'
 }
+$InputCsvFilePath = 'example.csv'
+$ThrottleLimit = 8
+Invoke-TlsProtocolTest -InputCsvFilePath $InputCsvFilePath -ThrottleLimit $ThrottleLimit

--- a/Example/example.csv
+++ b/Example/example.csv
@@ -1,3 +1,7 @@
-﻿Server,Ports
+﻿Server,Port
 github.com,443
 google.com,443
+ssllabs.com,443
+duckduckgo.com,443
+twitter.com,443
+owasp.org,443

--- a/Test-TlsProtocols/Test-TlsProtocols.psm1
+++ b/Test-TlsProtocols/Test-TlsProtocols.psm1
@@ -163,8 +163,11 @@ function Test-TlsProtocols {
                 $Fqdn = [System.Net.DNS]::GetHostByAddress($Server).HostName
                 $Ip = $Server
                 Write-Verbose "Server is an IP address with FQDN: $Fqdn"
-            } catch {
-                Write-Error "Unable to resolve IP address $Server to fqdn."
+            } 
+            # TO-DO: Should skip process block, but the code gets messy when accounting for all switches to keep objects the same.
+            # This is important when results are exported to a csv file.
+            catch {
+                Write-Verbose "Unable to resolve IP address $Server to fqdn."
             }
         }
         else {


### PR DESCRIPTION
If OS can be determined, find logical CPU count to use as ThrottleLimit.
Otherwise, default ThrottleLimit to 5 to align with Microsoft's default value.